### PR TITLE
Chaining pattern enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/*.log
+node_modules

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ function Matrix() {
 }
 Matrix.prototype.reset = function() {
 	this.m = [1, 0, 0, 1, 0, 0];
+  return this;
 };
 Matrix.prototype.multiply = function(matrix) {
 	var m11 = this.m[0] * matrix.m[0] + this.m[2] * matrix.m[1],
@@ -19,6 +20,7 @@ Matrix.prototype.multiply = function(matrix) {
 	this.m[3] = m22;
 	this.m[4] = dx;
 	this.m[5] = dy;
+  return this;
 };
 Matrix.prototype.inverse = function() {
 	var inv = new Matrix();
@@ -49,16 +51,19 @@ Matrix.prototype.rotate = function(rad) {
 	this.m[1] = m12;
 	this.m[2] = m21;
 	this.m[3] = m22;
+  return this;
 };
 Matrix.prototype.translate = function(x, y) {
 	this.m[4] += this.m[0] * x + this.m[2] * y;
 	this.m[5] += this.m[1] * x + this.m[3] * y;
+  return this;
 };
 Matrix.prototype.scale = function(sx, sy) {
 	this.m[0] *= sx;
 	this.m[1] *= sx;
 	this.m[2] *= sy;
 	this.m[3] *= sy;
+  return this;
 };
 Matrix.prototype.transformPoint = function(px, py) {
 	var x = px, y = py;

--- a/test/test.js
+++ b/test/test.js
@@ -28,4 +28,41 @@ describe("Matrix", function() {
 			assert.deepEqual(m.transformVector(point[0], point[1]), [point[0] * 3, point[1] * 2]);
 		});
 	});
+  describe("Create a 'blank' Matrix, execute transformation and return self", function() {
+    var m = new Matrix();
+    it("after translate, returned should be instance of Matrix", function() {
+      assert(m.translate(10,10) instanceof Matrix,'translate function returns instance of Matrix');
+    });
+    it("after scale, returned should be instance of Matrix", function() {
+      assert(m.scale(2,2) instanceof Matrix,'scale function returns instance of Matrix');
+    });
+    it("after rotate, returned should be instance of Matrix", function() {
+      assert(m.rotate(Math.PI / 180 * 45) instanceof Matrix,'rotate function returns instance of Matrix');
+    });
+    it("after inverse, returned should be instance of Matrix", function() {
+      assert(m.inverse() instanceof Matrix,'inverse function returns instance of Matrix');
+    });
+    it("after multiply, returned should be instance of Matrix", function() {
+      assert(m.multiply(new Matrix()) instanceof Matrix,'multiply function returns instance of Matrix');
+    });
+    it("after reset, returned should be instance of Matrix", function() {
+      assert(m.reset() instanceof Matrix,'reset function returns instance of Matrix');
+    });
+  });
+  describe("Create a 'blank' Matrix, execute transformation in chain", function() {
+    var m = new Matrix();
+    it("execute translate, scale, rotate in chain", function() {
+      assert.deepEqual(
+        m.translate(10,10)
+        .scale(2,2)
+        .rotate(Math.PI / 180 * 45).m,
+        [ 1.4142135623730951,
+          1.414213562373095,
+          -1.414213562373095,
+          1.4142135623730951,
+          10,
+          10 ]
+        );
+    });
+  });
 });


### PR DESCRIPTION
Chaining pattern enabled by returning `this` in applicable functions.
So it helps to write code like this:

``` javascript
var Matrix = require('node-transform-matrix'),
  m = new Matrix();
  m.translate(10,10)
    .scale(2,2)
    .rotate(.7);
```
